### PR TITLE
Correct the approach of obtain cfg from context

### DIFF
--- a/apps/fwd/src/main/java/org/onosproject/fwd/ReactiveForwarding.java
+++ b/apps/fwd/src/main/java/org/onosproject/fwd/ReactiveForwarding.java
@@ -80,7 +80,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -370,8 +369,8 @@ public class ReactiveForwarding {
                                               String propertyName) {
         Integer value = null;
         try {
-            String s = (String) properties.get(propertyName);
-            value = isNullOrEmpty(s) ? value : Integer.parseInt(s.trim());
+              Object obj = properties.get(propertyName);
+              value = obj == null ? value : (Integer) obj;
         } catch (NumberFormatException | ClassCastException e) {
             value = null;
         }
@@ -389,13 +388,13 @@ public class ReactiveForwarding {
                                              String propertyName) {
         boolean enabled = false;
         try {
-            String flag = (String) properties.get(propertyName);
+            Object flag = properties.get(propertyName);
             if (flag != null) {
                 enabled = flag.trim().equals("true");
             }
         } catch (ClassCastException e) {
             // No propertyName defined.
-            enabled = false;
+            enabled = (Boolean) flag;
         }
         return enabled;
     }


### PR DESCRIPTION
I have debug the isPropertyEnabled() and getIntegerProperty() step-by-step, and I found:

When we invoke 'context.getProperties().get()', it already returns the object of corresponding class,

for example:
context.getProperties().get("packetOutOnly") returns an obj of Boolean, for invoking at line 255: isPropertyEnabled(properties, "packetOutOnly");
context.getProperties().get("flowTimeout") returns an obj of Integer, for invoking at line 332: getIntegerProperty(properties, "flowTimeout");

Before my this commit, when it run to 
Line 373:  String s = (String) properties.get(propertyName);
and Line 392: String flag = (String) properties.get(propertyName);
it will throw an InvocationTargetException and will be catched as a ClassCastException, and then fail to read all of configurations.

Thank you very much!  R.S.V.P.

( I have made a review in Gerrit, too:  https://gerrit.onosproject.org/6924 )