### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/features/features.xml
+++ b/features/features.xml
@@ -51,7 +51,7 @@
         <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/2.7.0</bundle>
 
         <bundle>mvn:commons-configuration/commons-configuration/1.10</bundle>
-        <bundle>mvn:commons-collections/commons-collections/3.2.1</bundle>
+        <bundle>mvn:commons-collections/commons-collections/3.2.2</bundle>
 
         <bundle>mvn:com.typesafe/config/1.2.1</bundle>
         <bundle>mvn:org.onosproject/onlab-thirdparty/@ONOS-VERSION</bundle>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/