### PR TITLE
Updated onos.css and nav.css for better handling.

### DIFF
--- a/web/gui/src/main/webapp/app/fw/nav/nav.css
+++ b/web/gui/src/main/webapp/app/fw/nav/nav.css
@@ -19,6 +19,7 @@
  */
 
 #nav {
+    max-height: calc(100vh - 48px);
     position: absolute;
     top: 48px;
     left: 0;

--- a/web/gui/src/main/webapp/app/onos.css
+++ b/web/gui/src/main/webapp/app/onos.css
@@ -33,6 +33,7 @@ body {
     height: 100%;
     margin: 0;
     overflow: hidden;
+    position: absolute;
 }
 
 #view {

--- a/web/gui/src/main/webapp/app/onos.css
+++ b/web/gui/src/main/webapp/app/onos.css
@@ -30,10 +30,11 @@ html {
    for any flyout panes, that are positioned "off screen".
  */
 body {
-    height: 100%;
+    height: 100vh;
     margin: 0;
     overflow: hidden;
     position: absolute;
+    width: 100vw;
 }
 
 #view {


### PR DESCRIPTION
I added `position:absolute;` to body element so it's not possible anymore to move the whole view with the arrow keys, leaving huge empty areas.  
I also changed the body `width` and `height` to 100vw and 100vh respectively, so even on smaller views the whole screen is filled.

The problem can be seen here:
![onos](https://cloud.githubusercontent.com/assets/1199637/21043309/8ae0e8fa-bdf6-11e6-85cf-619227a049f7.png)

I manually set the body bg to RED.


For the nav element, I added a `max-height` property so that all nav elements can be reached even on small monitors.