### PR TITLE
reactive-routing bundle fix, configuration files copied to target directory, minor suggestions

### DIFF
--- a/apps/reactive-routing/BUCK
+++ b/apps/reactive-routing/BUCK
@@ -5,6 +5,10 @@ COMPILE_DEPS = [
     '//apps/intentsync:onos-apps-intentsync',
 ]
 
+BUNDLES = [
+    '//apps/routing-api:onos-apps-routing-api',
+]
+
 osgi_jar (
     deps = COMPILE_DEPS,
 )
@@ -14,5 +18,6 @@ onos_app (
     category = 'Traffic Steering',
     url = 'http://onosproject.org',
     description = 'SDN-IP reactive routing application.',
+    included_bundles = BUNDLES,
     required_apps = [ 'org.onosproject.intentsynchronizer' ],
 )

--- a/apps/routing/common/src/test/java/org/onosproject/routing/bgp/TestBgpPeerChannelHandler.java
+++ b/apps/routing/common/src/test/java/org/onosproject/routing/bgp/TestBgpPeerChannelHandler.java
@@ -199,7 +199,7 @@ class TestBgpPeerChannelHandler extends SimpleChannelHandler {
             message.writeByte(pathSegment.getType());
             message.writeByte(pathSegment.getSegmentAsNumbers().size());
             for (Long asNumber : pathSegment.getSegmentAsNumbers()) {
-                message.writeShort(asNumber.intValue());
+                message.writeInt(asNumber.intValue());
             }
         }
 

--- a/apps/routing/common/src/test/java/org/onosproject/routing/bgp/TestBgpPeerChannelHandler.java
+++ b/apps/routing/common/src/test/java/org/onosproject/routing/bgp/TestBgpPeerChannelHandler.java
@@ -199,7 +199,7 @@ class TestBgpPeerChannelHandler extends SimpleChannelHandler {
             message.writeByte(pathSegment.getType());
             message.writeByte(pathSegment.getSegmentAsNumbers().size());
             for (Long asNumber : pathSegment.getSegmentAsNumbers()) {
-                message.writeInt(asNumber.intValue());
+                message.writeShort(asNumber.intValue());
             }
         }
 

--- a/tools/package/onos-run-karaf
+++ b/tools/package/onos-run-karaf
@@ -63,7 +63,7 @@ if [ ! -d $ONOS_DIR -o "$oldMD5" != "$newMD5" -o -d $ONOS_DIR -a -n "$clean" ]; 
       "partitions": [ { "id": 1, "members": [ "$IP" ] } ]
     }
 EOF
-
+    cp -r $ONOS_ROOT/tools/package/config/* $ONOS_HOME/config/
 else
     # Otherwise, run using the previous installation
     echo "Running previous installation..."


### PR DESCRIPTION
- Reactive routing exception when activated

When activating reactive-routing application there is an bundle exception:

`2017-02-09 18:57:28,473 | WARN  | -message-handler | ApplicationManager               | 127 - org.onosproject.onos-core-net - 1.9.0.SNAPSHOT | Unable to perform operation on application org.onosproject.reactive-routing
java.lang.IllegalStateException: Can't install feature onos-apps-reactive-routing/0.0.0: 	
Could not start bundle mvn:org.onosproject/onos-apps-reactive-routing/1.9.0-SNAPSHOT in feature(s) onos-apps-reactive-routing-1.9.0-SNAPSHOT: Unresolved constraint in bundle org.onosproject.onos-apps-reactive-routing [176]: Unable to resolve 176.0: missing requirement [176.0] osgi.wiring.package; (&(osgi.wiring.package=org.onosproject.routing)(version>=1.9.0)(!(version>=2.0.0)))
	at org.apache.karaf.features.internal.FeaturesServiceImpl.installFeature(FeaturesServiceImpl.java:403)
	at org.apache.karaf.features.internal.FeaturesServiceImpl.installFeature(FeaturesServiceImpl.java:371)
	at org.apache.karaf.features.internal.FeaturesServiceImpl.installFeature(FeaturesServiceImpl.java:349)
	at Proxy650fc997_8709_4445_a4ca_646400ea98a3.installFeature(Unknown Source)
	at org.onosproject.app.impl.ApplicationManager.installAppFeatures(ApplicationManager.java:277)
	at org.onosproject.app.impl.ApplicationManager.access$200(ApplicationManager.java:66)
	at org.onosproject.app.impl.ApplicationManager$InternalStoreDelegate.notify(ApplicationManager.java:204)
	at org.onosproject.app.impl.ApplicationManager$InternalStoreDelegate.notify(ApplicationManager.java:196)
	at org.onosproject.store.AbstractStore.notifyDelegate(AbstractStore.java:58)[125:org.onosproject.onos-api:1.9.0.SNAPSHOT]
	at org.onosproject.store.app.DistributedApplicationStore.access$500(DistributedApplicationStore.java:95)[129:org.onosproject.onos-core-dist:1.9.0.SNAPSHOT]
	at org.onosproject.store.app.DistributedApplicationStore$AppActivator.accept(DistributedApplicationStore.java:439)[129:org.onosproject.onos-core-dist:1.9.0.SNAPSHOT]
	at org.onosproject.store.app.DistributedApplicationStore$AppActivator.accept(DistributedApplicationStore.java:433)[129:org.onosproject.onos-core-dist:1.9.0.SNAPSHOT]
	at org.onosproject.store.primitives.impl.DefaultDistributedTopic.lambda$null$0(DefaultDistributedTopic.java:67)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)[:1.8.0_121]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)[:1.8.0_121]
	at java.lang.Thread.run(Thread.java:745)[:1.8.0_121]
`

To solve this I added the routing-api BUNDLE to the reactive-routing BUCK file.

- Copy default configuration folder to target directory

Configuration folder at /tools/package/config/ is not copied when running onos-local inside the $ONOS_HOME/config/ folder making network configuration loader to fail.

To solve this I added inside tools/package/onos-run-karaf a copy command of the whole config directory to the target directory.

**_Minor suggestions:_**

- Naming of reactive routing

The reactive-routing application is with a dash (-) in pom.xml but in the configuration loader the app id is with a dot (.)

`
REACTIVE_ROUTING_APP_ID = "org.onosproject.reactive.routing"
`
but
`
<module>reactive-routing</module>
`

- Prepare BGP Update 
 
While I was using the prepare BGP update function to construct custom BGP messages they where being rejected because it was sending 2-octet ASNs instead of 4-octets ASNs. 
(This should be fixed if in future ONOS will construct BGP Update messages)

**TestBgpPeerChannelHanlder.java:202**
`
message.writeShort(asNumber.intValue()); -> message.writeInt(asNumber.intValue()); 
`
