### PR TITLE
Modified onos/tools/dev/bin/onos-setup-p4-dev.

### DIFF
--- a/tools/dev/bin/onos-setup-p4-dev
+++ b/tools/dev/bin/onos-setup-p4-dev
@@ -101,7 +101,7 @@ function do_requirements_1604 {
         ca-certificates \
         cmake \
         g++ \
-        libboost-iostreams1.58-dev
+        libboost-iostreams-dev
 }
 
 function do_protobuf {


### PR DESCRIPTION
Running onos-setup-p4-dev on Lubuntu 17.04.
( Linux 4.10.0-35-generic #39-Ubuntu SMP Wed Sep 13 07:46:59 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux )

Found that only have in function `do_requirements_1604`, package `libboost-iostreams1.58-dev` not found, and the oldest one is `libboost-iostreams1.61-dev`, so remove the `1.58` to pass the building process.

Or maybe create another function as `do_requirements_1704` to deal with it?