### PR TITLE
Five tuple path selection constraint

### DIFF
--- a/cli/src/main/java/org/onosproject/cli/net/ConnectivityIntentCommand.java
+++ b/cli/src/main/java/org/onosproject/cli/net/ConnectivityIntentCommand.java
@@ -39,6 +39,7 @@ import org.onosproject.net.intent.Key;
 import org.onosproject.net.intent.constraint.BandwidthConstraint;
 import org.onosproject.net.intent.constraint.DomainConstraint;
 import org.onosproject.net.intent.constraint.EncapsulationConstraint;
+import org.onosproject.net.intent.constraint.FiveTuplePathSelectionConstraint;
 import org.onosproject.net.intent.constraint.HashedPathSelectionConstraint;
 import org.onosproject.net.intent.constraint.LatencyConstraint;
 import org.onosproject.net.intent.constraint.PartialFailureConstraint;
@@ -185,6 +186,10 @@ public abstract class ConnectivityIntentCommand extends AbstractShellCommand {
     @Option(name = "--hashed", description = "Hashed path selection",
             required = false, multiValued = false)
     private boolean hashedPathSelection = false;
+
+    @Option(name = "--fiveTuple", description = "Five tuple based path selection",
+            required = false, multiValued = false)
+    private boolean fiveTuplePathSelection = false;
 
     @Option(name = "--domains", description = "Allow domain delegation",
             required = false, multiValued = false)
@@ -412,6 +417,11 @@ public abstract class ConnectivityIntentCommand extends AbstractShellCommand {
         // Check for hashed path selection
         if (hashedPathSelection) {
             constraints.add(new HashedPathSelectionConstraint());
+        }
+
+        // Check for five tuple path selection
+        if (fiveTuplePathSelection) {
+            constraints.add(new FiveTuplePathSelectionConstraint());
         }
 
         // Check for domain processing

--- a/core/api/src/main/java/org/onosproject/net/intent/constraint/FiveTuplePathSelectionConstraint.java
+++ b/core/api/src/main/java/org/onosproject/net/intent/constraint/FiveTuplePathSelectionConstraint.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onosproject.net.intent.constraint;
+
+/**
+ * A constraint for five-tuple intent based path selection.
+ */
+public final class FiveTuplePathSelectionConstraint extends MarkerConstraint {
+
+}

--- a/core/common/src/main/java/org/onosproject/codec/impl/DecodeConstraintCodecHelper.java
+++ b/core/common/src/main/java/org/onosproject/codec/impl/DecodeConstraintCodecHelper.java
@@ -27,6 +27,7 @@ import org.onosproject.net.intent.constraint.AnnotationConstraint;
 import org.onosproject.net.intent.constraint.AsymmetricPathConstraint;
 import org.onosproject.net.intent.constraint.BandwidthConstraint;
 import org.onosproject.net.intent.constraint.DomainConstraint;
+import org.onosproject.net.intent.constraint.FiveTuplePathSelectionConstraint;
 import org.onosproject.net.intent.constraint.LatencyConstraint;
 import org.onosproject.net.intent.constraint.LinkTypeConstraint;
 import org.onosproject.net.intent.constraint.NonDisruptiveConstraint;
@@ -193,6 +194,16 @@ public final class DecodeConstraintCodecHelper {
         return nonDisruptive();
     }
 
+
+    /**
+     * Decodes a five tuple path selection constraint.
+     *
+     * @return five tuple path selection constraint object.
+     */
+    private Constraint decodeFiveTuplePathSelectionConstraint() {
+        return new FiveTuplePathSelectionConstraint();
+    }
+
     /**
      * Decodes the given constraint.
      *
@@ -221,6 +232,8 @@ public final class DecodeConstraintCodecHelper {
             return decodeDomainConstraint();
         } else if (type.equals(NonDisruptiveConstraint.class.getSimpleName())) {
             return decodeNonDisruptiveConstraint();
+        } else if (type.equals(FiveTuplePathSelectionConstraint.class.getSimpleName())) {
+            return decodeFiveTuplePathSelectionConstraint();
         }
         throw new IllegalArgumentException("Instruction type "
                 + type + " is not supported");

--- a/core/net/src/main/java/org/onosproject/net/intent/impl/compiler/ConnectivityIntentCompiler.java
+++ b/core/net/src/main/java/org/onosproject/net/intent/impl/compiler/ConnectivityIntentCompiler.java
@@ -29,13 +29,20 @@ import org.onosproject.net.ConnectPoint;
 import org.onosproject.net.DeviceId;
 import org.onosproject.net.DisjointPath;
 import org.onosproject.net.ElementId;
+import org.onosproject.net.Host;
 import org.onosproject.net.Path;
 import org.onosproject.net.device.DeviceService;
+import org.onosproject.net.flow.TrafficSelector;
+import org.onosproject.net.flow.criteria.Criterion;
+import org.onosproject.net.flow.criteria.IPProtocolCriterion;
+import org.onosproject.net.host.HostService;
 import org.onosproject.net.intent.ConnectivityIntent;
 import org.onosproject.net.intent.Constraint;
+import org.onosproject.net.intent.HostToHostIntent;
 import org.onosproject.net.intent.IntentCompiler;
 import org.onosproject.net.intent.IntentExtensionService;
 import org.onosproject.net.intent.constraint.BandwidthConstraint;
+import org.onosproject.net.intent.constraint.FiveTuplePathSelectionConstraint;
 import org.onosproject.net.intent.constraint.HashedPathSelectionConstraint;
 import org.onosproject.net.intent.constraint.MarkerConstraint;
 import org.onosproject.net.intent.constraint.PathViabilityConstraint;
@@ -56,8 +63,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -157,6 +166,8 @@ public abstract class ConnectivityIntentCompiler<T extends ConnectivityIntent>
 
         if (constraints.stream().anyMatch(c -> c instanceof HashedPathSelectionConstraint)) {
             return filtered.get(intent.hashCode() % filtered.size());
+        } else if (constraints.stream().anyMatch(c -> c instanceof FiveTuplePathSelectionConstraint)) {
+            return filtered.get(Math.floorMod(this.getFiveTupleHash(intent), filtered.size()));
         }
 
         return filtered.iterator().next();
@@ -183,11 +194,70 @@ public abstract class ConnectivityIntentCompiler<T extends ConnectivityIntent>
             throw new PathNotFoundException(one, two);
         }
 
-        if (constraints.stream().anyMatch(c -> c instanceof HashedPathSelectionConstraint)) {
+        if (constraints.stream().anyMatch(c -> c instanceof HashedPathSelectionConstraint))
+        {
             return filtered.get(intent.hashCode() % filtered.size());
+        } else if (constraints.stream().anyMatch(c -> c instanceof FiveTuplePathSelectionConstraint)) {
+            return filtered.get(Math.floorMod(this.getFiveTupleHash(intent), filtered.size()));
         }
 
         return filtered.iterator().next();
+    }
+
+    /**
+     * A hash value is calculated based on the intents characteristic. It is
+     * based on the src/dst IP, IP protocol type, and src/dst transport protocol port.
+     *
+     * @param intent the intent a five tuple hash should be calculated with
+     * @return the hash value based on the five tuple of the intent
+     */
+    protected int getFiveTupleHash(ConnectivityIntent intent) {
+
+        Map<Short, Criterion.Type> ipProtoSrcMap = new HashMap<Short, Criterion.Type>();
+        ipProtoSrcMap.put((short) 6, Criterion.Type.TCP_SRC);
+        ipProtoSrcMap.put((short) 17, Criterion.Type.UDP_SRC);
+        ipProtoSrcMap.put((short) 132, Criterion.Type.SCTP_SRC);
+        Map<Short, Criterion.Type> ipProtoDstMap = new HashMap<Short, Criterion.Type>();
+        ipProtoDstMap.put((short) 6, Criterion.Type.TCP_DST);
+        ipProtoDstMap.put((short) 17, Criterion.Type.UDP_DST);
+        ipProtoDstMap.put((short) 132, Criterion.Type.SCTP_DST);
+
+        TrafficSelector selector = intent.selector();
+
+        int hash = 0;
+
+        // create hash code based on ip addresses
+        if (intent.getClass().equals(HostToHostIntent.class)) {
+            HostToHostIntent h2hIntent = (HostToHostIntent) intent;
+            HostService hs = ((HostToHostIntentCompiler) this).hostService;
+            Host[] hosts = {hs.getHost(h2hIntent.one()), hs.getHost(h2hIntent.two())};
+
+            for (Host host : hosts) {
+                if (host != null) {
+                    hash = 31 * hash + (host.ipAddresses() != null ? host.ipAddresses().hashCode() : 0);
+                }
+            }
+        }
+
+        // ip protocol
+        hash = 31 * hash + (selector.getCriterion(Criterion.Type.IP_PROTO) != null ?
+                selector.getCriterion(Criterion.Type.IP_PROTO).hashCode() : 0);
+
+        if (selector.getCriterion(Criterion.Type.IP_PROTO) != null) {
+            IPProtocolCriterion ipProtoCrit = (IPProtocolCriterion) selector.getCriterion(Criterion.Type.IP_PROTO);
+            // protocol src port
+            if (ipProtoSrcMap.containsKey(ipProtoCrit.protocol())) {
+                hash = 31 * hash + (selector.getCriterion(ipProtoSrcMap.get(ipProtoCrit.protocol())) != null ?
+                        selector.getCriterion(ipProtoSrcMap.get(ipProtoCrit.protocol())).hashCode() : 0);
+            }
+            // protocol dst port
+            if (ipProtoDstMap.containsKey(ipProtoCrit.protocol())) {
+                hash = 31 * hash + (selector.getCriterion(ipProtoDstMap.get(ipProtoCrit.protocol())) != null ?
+                        selector.getCriterion(ipProtoDstMap.get(ipProtoCrit.protocol())).hashCode() : 0);
+            }
+        }
+
+        return hash;
     }
 
     /**

--- a/core/store/serializers/src/main/java/org/onosproject/store/serializers/KryoNamespaces.java
+++ b/core/store/serializers/src/main/java/org/onosproject/store/serializers/KryoNamespaces.java
@@ -190,6 +190,7 @@ import org.onosproject.net.intent.constraint.BandwidthConstraint;
 import org.onosproject.net.intent.constraint.BooleanConstraint;
 import org.onosproject.net.intent.constraint.DomainConstraint;
 import org.onosproject.net.intent.constraint.EncapsulationConstraint;
+import org.onosproject.net.intent.constraint.FiveTuplePathSelectionConstraint;
 import org.onosproject.net.intent.constraint.HashedPathSelectionConstraint;
 import org.onosproject.net.intent.constraint.LatencyConstraint;
 import org.onosproject.net.intent.constraint.LinkTypeConstraint;
@@ -577,6 +578,7 @@ public final class KryoNamespaces {
                     EncapsulationConstraint.class,
                     EncapsulationType.class,
                     HashedPathSelectionConstraint.class,
+                    FiveTuplePathSelectionConstraint.class,
                     NonDisruptiveConstraint.class,
                     // Flow Objectives
                     DefaultForwardingObjective.class,


### PR DESCRIPTION
Possibility to choose an connectivity intent path based on the five tuple hash of the intent. This hash is calculated with the source/destination IP address, the transport protocol type, and the transport protocol source/destination.
Equal traffic is forwarded over the same paths, while the overall traffic is distributed evenly on the network. This leads to a predictable traffic distribution, as the same flow is always installed on the same path.