### PR TITLE
Include dependency of `onos-user-key`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM anapsix/alpine-java:8_server-jre
 
 # Change to /root directory
 RUN apk update && \
-        apk add curl && \
+        apk add curl openssh && \
         mkdir -p /root/onos
 WORKDIR /root/onos
 


### PR DESCRIPTION
The second stage container image does not contain `ssh-keygen` which is required by `onos-user-key`.
Commit https://github.com/opennetworkinglab/onos/commit/0fe2138541c0c9d7370a9c05a167209410bcf7de already did this before the  `Dockerfile` was changed to use second stage containers.